### PR TITLE
WIP: api: check certificate revocation list when client cert is presented

### DIFF
--- a/api-server/Makefile
+++ b/api-server/Makefile
@@ -4,6 +4,7 @@ REPOSITORY  := <docker-repo-path>/arc-api
 TAG         ?= latest
 IMAGE       := $(REPOSITORY):$(TAG)
 BUILD_IMAGE := sapcc/gobuild:1.10-alpine
+export GO111MODULE=off
 
 ifneq ($(BUILD_VERSION),)
 LDFLAGS += -X github.com/sapcc/arc/version.Version=$(BUILD_VERSION)

--- a/api-server/app.go
+++ b/api-server/app.go
@@ -151,6 +151,11 @@ func main() {
 			EnvVar: envPrefix + "PKI_CA_KEY",
 		},
 		cli.StringFlag{
+			Name:   "pki-ca-crl",
+			Usage:  "PKI CA certificate revocation list",
+			EnvVar: envPrefix + "PKI_CA_CRL",
+		},
+		cli.StringFlag{
 			Name:   "agent-update-url",
 			Usage:  "The default update URL for agents. Only used for agent install script.",
 			EnvVar: envPrefix + "AGENT_UPDATE_URL",
@@ -281,7 +286,7 @@ func runServer(c *cli.Context) {
 	router := newRouter(env)
 
 	// run server
-	server := NewSever(c.GlobalString("tls-server-cert"), c.GlobalString("tls-server-key"), c.GlobalString("pki-ca-cert"), c.GlobalString("bind-address"), c.GlobalString("bind-address-tls"), router)
+	server := NewSever(c.GlobalString("tls-server-cert"), c.GlobalString("tls-server-key"), c.GlobalString("pki-ca-cert"), c.GlobalString("pki-ca-crl"), c.GlobalString("bind-address"), c.GlobalString("bind-address-tls"), router)
 	go server.run()
 
 	// catch gracefull shutdown and shutdown to close the connetions

--- a/api-server/pki/renew.go
+++ b/api-server/pki/renew.go
@@ -47,13 +47,11 @@ func CheckAndRenewCert(cfg *arc_config.Config, renewURI string, renewThreshold i
 
 // RenewCert renew the cert
 func RenewCert(cfg *arc_config.Config, renewURI string, httpClientInsecureSkipVerify bool) error {
-	// #nosec: TLS InsecureSkipVerify set true
 	// client creation
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				Certificates:       []tls.Certificate{*cfg.ClientCert},
-				InsecureSkipVerify: httpClientInsecureSkipVerify,
+				Certificates: []tls.Certificate{*cfg.ClientCert},
 			},
 		},
 	}


### PR DESCRIPTION
This is an untested dry coding to have the apiserver check an optional url list when handling requests with were a client certificate was presented.

@ArtieReus Can you please take over and do some testing that this actually works and that the api also still works without client certificates.